### PR TITLE
Adiciona suporte a Redis

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 DATABASE_URL=postgres://SYSDBA:masterkey@localhost/minervadb
+REDIS_URL=redis://localhost:6379
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,9 @@ dependencies = [
  "dotenv",
  "num-derive",
  "num-traits",
+ "r2d2",
+ "r2d2_redis",
+ "redis 0.21.1",
  "rocket",
  "rocket_sync_db_pools",
  "serde",
@@ -157,6 +160,16 @@ dependencies = [
  "num-traits",
  "time 0.1.43",
  "winapi",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a909e4d93292cd8e9c42e189f61681eff9d67b6541f96b8a1a737f23737bd001"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -304,6 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "ed25519"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +365,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -573,6 +602,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +707,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -930,6 +976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2_redis"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "182473b876b0b93e353682ec58e207dd1cb4a62278bbe0045fe52b86b74363bb"
+dependencies = [
+ "r2d2",
+ "redis 0.20.2",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1023,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "redis"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f0ceb2ec0dd769483ecd283f6615aa83dcd0be556d5294c6e659caefe7cc54"
+dependencies = [
+ "async-trait",
+ "combine",
+ "dtoa",
+ "itoa",
+ "percent-encoding",
+ "sha1",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d99f2a2f80b100036dde5f8ae106546196592751f35c7afb58ec0683059a3e"
+dependencies = [
+ "async-trait",
+ "combine",
+ "dtoa",
+ "itoa",
+ "percent-encoding",
+ "sha1",
+ "url",
 ]
 
 [[package]]
@@ -1461,6 +1547,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1693,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1724,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ diesel-enum = "0.0.4"
 chrono = "0.4.19"
 comfy-table = "4.1.1"
 sodiumoxide = ">= 0.2.7"
+redis = "0.21.1"
+r2d2 = "*"
+r2d2_redis = "*"
 
 [dependencies.rocket_sync_db_pools]
 version = "0.1.0-rc.1"

--- a/README.org
+++ b/README.org
@@ -73,6 +73,31 @@ docker stop minervadb
 docker logs minervadb
 #+end_src
 
+* Configuração do Redis
+
+O comando  a seguir  cria um  contêiner de uma  instância do  Redis 6,
+usando Docker.
+
+#+begin_src bash
+docker run --name minerva-redis \
+       -p 6379:6379 \
+       -d redis:6
+#+end_src
+
+Assim como  no caso  do contêiner  do banco de  dados, convém  usar os
+comandos do Docker para gerenciamento.
+
+#+begin_src bash
+docker start minerva-redis # Iniciar
+docker stop minerva-redis  # Matar
+docker logs minerva-redis  # Logs
+#+end_src
+
+* Criando migrations
+
+Os  comandos  a  seguir  mostram  como  criar  novas  migrations  para
+modificações no banco de dados.
+
 ** Preparação inicial do banco de dados
 
 Execute o comando abaixo  para fazer com que o Diesel  crie o banco de
@@ -93,11 +118,6 @@ repositório.
 
 Para maiores  informações, veja ~diesel  --help~ ou a  documentação do
 ~diesel~.
-
-* Criando migrations
-
-Os  comandos  a  seguir  mostram  como  criar  novas  migrations  para
-modificações no banco de dados.
 
 ** Criando nova migration
 

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,5 +1,5 @@
-[development]
-address = "localhost"
+[debug]
+address = "127.0.0.1"
 port    = 8000
 
 [release]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+pub mod redis;
+
 use diesel::r2d2::{ ConnectionManager, Pool };
 use diesel::PgConnection;
 use dotenv::dotenv;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -16,6 +16,8 @@
 
 pub mod redis;
 
+pub use crate::db::redis::{ RedisPool, cria_pool_redis };
+
 use diesel::r2d2::{ ConnectionManager, Pool };
 use diesel::PgConnection;
 use dotenv::dotenv;

--- a/src/db/redis.rs
+++ b/src/db/redis.rs
@@ -1,4 +1,4 @@
-// lib.rs -- Uma parte de Minerva.rs
+// db/redis.rs -- Uma parte de Minerva.rs
 // Copyright (C) 2021 Lucas S. Vieira
 //
 // This program is free software: you can redistribute it and/or modify
@@ -14,22 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use] extern crate rocket;
-#[macro_use] extern crate diesel;
-extern crate dotenv;
-extern crate serde;
-extern crate serde_json;
-extern crate bigdecimal;
-#[macro_use] extern crate num_derive;
-extern crate num_traits;
-extern crate diesel_enum;
-extern crate chrono;
-extern crate comfy_table;
-extern crate r2d2_redis;
+use r2d2_redis::{ r2d2, RedisConnectionManager };
+use std::env;
+use dotenv::dotenv;
 
-pub mod db;
-pub mod model;
-pub mod controller;
-pub mod routes;
+pub type RedisPool = r2d2::Pool<RedisConnectionManager>;
 
-pub mod inpututils;
+pub fn cria_pool_redis() -> RedisPool {
+    dotenv().ok();
+
+    let redis_url = env::var("REDIS_URL")
+        .expect("Necessário definir o URL do Redis em REDIS_URL");
+
+    let manager = RedisConnectionManager::new(redis_url)
+        .expect("Falha ao criar gerente de conexões do Redis.");
+
+    r2d2::Pool::builder()
+        .build(manager)
+        .expect("Falha ao criar pool do Redis.")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ extern crate num_traits;
 extern crate diesel_enum;
 extern crate chrono;
 extern crate comfy_table;
+extern crate r2d2_redis;
 
 pub mod db;
 pub mod model;
@@ -35,9 +36,12 @@ pub mod routes;
 fn launch() -> _ {
     let pool = db::cria_pool_conexoes();
     db::garante_usuario_inicial(&pool);
-    
+   
+    let redis_pool = db::redis::cria_pool_redis();
+
     rocket::build()
         .manage(pool)
+        .manage(redis_pool)
         .mount("/", routes![ routes::index ])
         .mount("/clientes", routes::clientes::constroi_rotas())
         .mount("/produtos", routes::produtos::constroi_rotas())

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn launch() -> _ {
     let pool = db::cria_pool_conexoes();
     db::garante_usuario_inicial(&pool);
    
-    let redis_pool = db::redis::cria_pool_redis();
+    let redis_pool = db::cria_pool_redis();
 
     rocket::build()
         .manage(pool)


### PR DESCRIPTION
Adiciona suporte a Redis via pooling de conexão. O estado é gerenciado pelo próprio Rocket. Requer o uso de Heroku Redis no Heroku.