### PR TITLE
Adiciona configuração do Docker Compose

### DIFF
--- a/README.org
+++ b/README.org
@@ -500,10 +500,29 @@ docker compose up
 #+end_src
 
 Este comando baixará as  imagens do PostgreSQL e do Redis,  e também compilará a
-imagem do webservice Minerva.
+imagem do webservice  Minerva, que estará disponível para acesso  na sua máquina
+sob a porta ~8000~.
 
 Caso você queira remover todos os traços dos contêineres do projeto, use:
 
 #+begin_src bash
 docker compose -v down
 #+end_src
+
+** Acesso ao banco de dados com PgAdmin4
+
+Caso  você queira  acessar e  gerenciar  o banco  de dados  via PgAdmin4,  basta
+executar o serviço via Docker Compose no profile de Debug:
+
+#+begin_src bash
+docker compose --profile debug up
+#+end_src
+
+É bem provável que o PgAdmin4  demore um pouco para inicializar, portanto, fique
+atento ao log do comando.
+
+Após tudo estar pronto, o PgAdmin4  poderá ser acessado em ~localhost:8484~. Use
+o e-mail ~admin@example.com~ e a senha  ~123456~. Para acessar o banco de dados,
+use também a senha ~123456~.
+
+

--- a/README.org
+++ b/README.org
@@ -485,3 +485,25 @@ Isso  fará com  que o  ambiente  use as  mesmas variáveis  descritas no  arqui
 ~.env~, bem como considerará as portas da  máquina host para conexão com o Redis
 e o PostgreSQL.
 
+* Executando o projeto completo com Docker Compose
+
+É possível também  executar o projeto completo (Webservice REST,  banco de dados
+PostgreSQL 14 e Redis 6) através do Docker Compose. Para isso, existe um arquivo
+~docker-compose.yml~  na raiz  deste  projeto, pronto  para  ser utilizado,  que
+vale-se de algumas das configurações usadas  para construção da imagem Docker do
+serviço.
+
+Para executar o projeto, vá até a raiz do repositório e execute:
+
+#+begin_src bash
+docker compose up
+#+end_src
+
+Este comando baixará as  imagens do PostgreSQL e do Redis,  e também compilará a
+imagem do webservice Minerva.
+
+Caso você queira remover todos os traços dos contêineres do projeto, use:
+
+#+begin_src bash
+docker compose -v down
+#+end_src

--- a/README.org
+++ b/README.org
@@ -522,7 +522,7 @@ docker compose --profile debug up
 atento ao log do comando.
 
 Após tudo estar pronto, o PgAdmin4  poderá ser acessado em ~localhost:8484~. Use
-o e-mail ~admin@example.com~ e a senha  ~123456~. Para acessar o banco de dados,
+o e-mail  ~admin@admin.com~ e a senha  ~123456~. Para acessar o  banco de dados,
 use também a senha ~123456~.
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,18 +28,16 @@ services:
   # Pgadmin4 - Porta padrão: 80 / Porta: 8484
   pgadmin:
     environment:
-      - PGADMIN_DEFAULT_EMAIL=admin@example.com
+      - PGADMIN_DEFAULT_EMAIL=admin@admin.com
       - PGADMIN_DEFAULT_PASSWORD=123456
+      - GUNICORN_ACCESS_LOGFILE=/dev/null
     build:
       dockerfile: Dockerfile
       context: docker/pgadmin
     ports:
       - "8484:80"
-    restart: on-failure:5
     profiles:
       - debug
-    depends_on:
-      - "postgresql"
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  # Serviço REST
+  webservice:
+    build: .
+    environment:
+      - DATABASE_URL=postgres://postgres:123456@postgresql/minervadb
+      - REDIS_URL=redis://redis:6379
+    ports:
+      - "8000:8000"
+    restart: on-failure:5
+
+  # Banco de dados - Porta padrão: 5432
+  postgresql:
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=123456
+      - POSTGRES_DB=minervadb
+    image: postgres:14
+
+  # Redis - Porta padrão: 6379
+  redis:
+    image: redis:6
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,19 @@ services:
   redis:
     image: redis:6
 
+  # Pgadmin4 - Porta padrão: 80 / Porta: 8484
+  pgadmin:
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@example.com
+      - PGADMIN_DEFAULT_PASSWORD=123456
+    build:
+      dockerfile: Dockerfile
+      context: docker/pgadmin
+    ports:
+      - "8484:80"
+    restart: on-failure:5
+    profiles:
+      - debug
+
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
     ports:
       - "8000:8000"
     restart: on-failure:5
+    depends_on:
+      - "postgresql"
+      - "redis"
 
   # Banco de dados - Porta padrão: 5432
   postgresql:
@@ -35,6 +38,9 @@ services:
     restart: on-failure:5
     profiles:
       - debug
+    depends_on:
+      - "postgresql"
+
 
 
 

--- a/docker/pgadmin/Dockerfile
+++ b/docker/pgadmin/Dockerfile
@@ -1,0 +1,4 @@
+# Este Dockerfile existe meramente para que o serviço do
+# pgadmin4 seja disponibilizado via Docker Compose.
+FROM dpage/pgadmin4
+COPY servers.json /pgadmin4/servers.json

--- a/docker/pgadmin/servers.json
+++ b/docker/pgadmin/servers.json
@@ -2,7 +2,7 @@
     "Servers": {
 	"1": {
 	    "Name": "Minerva",
-	    "Group": "Databases",
+	    "Group": "Servers",
 	    "Host": "postgresql",
 	    "Port": 5432,
 	    "MaintenanceDB": "postgres",

--- a/docker/pgadmin/servers.json
+++ b/docker/pgadmin/servers.json
@@ -1,0 +1,14 @@
+{
+    "Servers": {
+	"1": {
+	    "Name": "Minerva",
+	    "Group": "Databases",
+	    "Host": "postgresql",
+	    "Port": 5432,
+	    "MaintenanceDB": "postgres",
+	    "Username": "postgres",
+	    "SSLMode": "prefer",
+	    "PassFile": "/pgpassfile"
+	}
+    }
+}


### PR DESCRIPTION
Este PR cria a configuração inicial para execução do Minerva com Docker Compose.
Foi adicionado também um profile de `debug` onde o serviço do PgAdmin 4 poderá ser acessado para monitorar o banco de dados.
Em suma, o Docker Compose fará o seguinte:

- Executará os contêineres contendo o PostgreSQL 14, o Redis 6 e o Minerva, em uma rede virtual;
- Sob o profile de `debug`, executará mais um contêiner do PgAdmin 4, com configuração pré-definida, na mesma rede virtual;
- Deixará o Minerva acessível localmente sob o endereço `http://localhost:8000`;
- Deixará o PgAdmin acessível localmente sob o endereço `http://localhost:8484`.

